### PR TITLE
Fix Redis deprecation warning: use aclose() instead of close()

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,11 +89,9 @@ async def _run_blocking(func, *args, **kwargs):
 
 
 async def _close_redis(redis: Redis):
-    """Best-effort close of redis client + pool (supports sync/async methods)."""
+    """Best-effort close of redis client + pool (supports async methods)."""
     try:
-        res = redis.close()
-        if inspect.isawaitable(res):
-            await res
+        await redis.aclose()
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Problem
Redis client throws deprecation warning:
```
DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
```

## Solution
Updated `_close_redis()` function in `main.py` to use `await redis.aclose()` instead of the deprecated `redis.close()` method.

## Changes
- Replaced `redis.close()` with `await redis.aclose()` in the `_close_redis()` function
- Simplified the function by removing unnecessary `inspect.isawaitable()` check since `aclose()` is always async
- Updated function docstring to reflect async-only behavior

## Testing
- ✅ Bot starts successfully
- ✅ No deprecation warnings during shutdown
- ✅ Redis connection closes properly